### PR TITLE
Control manager can be extended by user through a function pointer passed on through main.c 

### DIFF
--- a/app/main.c
+++ b/app/main.c
@@ -11,7 +11,9 @@
 #include "lib/xmem/xmem.h"
 
 #ifdef DEBUG
+
 #include "lib/controlmanager/controlmanager.h"
+
 #endif
 
 //the following ISR's have to be comment in by programmer
@@ -35,21 +37,18 @@ ISR(FPGA_DONE_INT_VECTOR) {
 }
 */
 
-int main(void)
-{
+void handleCharInput(uint8_t currentData);
 
+int main(void) {
     led_mcu_init();
-
+#ifdef DEBUG
     debugInit(NULL);
-
-    // in uartmanger for specific use case
-    // initialises the flash and spi together
-//    initFlash();
-
-//    reconfigure_initMultiboot();
+    control_setUserHandle(&handleCharInput);
+#endif
 
     // need a delay for initialise and reboot the mcu
     // first led should blink
+
     elasticnode_initialise();
     elasticnode_fpgaPowerOff();
     led_mcu_turnOn(0);
@@ -62,16 +61,25 @@ int main(void)
         //your implementation
 
 #ifdef DEBUG
-        if(debugReadCharAvailable())
-        {
+        // have after each cycle a moment to see if we have a user interaction
+        if (debugReadCharAvailable()) {
             uint8_t data = debugGetChar();
             // acknowledge when ready to receive again
 //            debugAck(data);
-            uartProcessInput(data);
+            control_handleChar(data);
         }
         debugTask();
 #endif
     }
     return 0;
 
+}
+
+void handleCharInput(uint8_t currentData) {
+    //TODO: Please fill this with custom command handling where necessary
+    switch (currentData) {
+        default:
+            debugWriteLine("default user level command handle\r\n");
+            break;
+    }
 }

--- a/app/main.c
+++ b/app/main.c
@@ -64,15 +64,13 @@ int main(void) {
         // have after each cycle a moment to see if we have a user interaction
         if (debugReadCharAvailable()) {
             uint8_t data = debugGetChar();
-            // acknowledge when ready to receive again
-//            debugAck(data);
             control_handleChar(data);
         }
         debugTask();
 #endif
+
     }
     return 0;
-
 }
 
 void handleCharInput(uint8_t currentData) {

--- a/lib/controlmanager/controlmanager.c
+++ b/lib/controlmanager/controlmanager.c
@@ -1,46 +1,50 @@
-#include "EmbeddedUtilities/BitManipulation.h"
 
-#include "lib/configuration/configuration.h"
-#include "lib/debug/debug.h"
-#include "lib/elasticNodeMiddleware/elasticNodeMiddleware.h"
-#include "lib/elasticNodeMiddleware/elasticNodeMiddleware_internal.h"
-#include "lib/flash/flash.h"
-#include "lib/pinDefinition/fpgaPins.h"
-#include "lib/pinDefinition/fpgaRegisters.h"
-#include "lib/reconfigure_multiboot_avr/reconfigure_multiboot_avr.h"
-#include "lib/reconfigure_multiboot_avr/reconfigure_multiboot_internal_avr.h"
-#include "lib/spi/spi.h"
 #include "lib/controlmanager/controlmanager.h"
+#include "lib/configuration/configuration.h"
 #include "lib/xmem/xmem.h"
+#include "lib/debug/debug.h"
+#include "lib/flash/flash.h"
+
+//#include "EmbeddedUtilities/BitManipulation.h"
+//
+//#include "lib/elasticNodeMiddleware/elasticNodeMiddleware.h"
+//#include "lib/elasticNodeMiddleware/elasticNodeMiddleware_internal.h"
+//#include "lib/pinDefinition/fpgaPins.h"
+//#include "lib/pinDefinition/fpgaRegisters.h"
+//#include "lib/reconfigure_multiboot_avr/reconfigure_multiboot_avr.h"
+//#include "lib/reconfigure_multiboot_avr/reconfigure_multiboot_internal_avr.h"
+//#include "lib/spi/spi.h"
 
 //#include "lib/leds/leds.h"
 
 uartReceiveMode currentUartReceiveMode = UART_IDLE;
-loadingMode currentLoadingMode = LOADING_IDLE;
+//loadingMode currentLoadingMode = LOADING_IDLE;
 
 uint8_t *data;
 
 volatile uint8_t *addr_led = (uint8_t *) (XMEM_OFFSET + 0x03);
 
-//=================================================================================
+
+volatile uint8_t *userlogic_reset_addr = (uint8_t *) (XMEM_OFFSET + 0x04);
+volatile uint8_t *userlogic_id_addr = (uint8_t *) (XMEM_USERLOGIC_OFFSET + 1500);
+void dummyHandler(uint8_t currentData);
+void (*userDefinedHandler)(uint8_t) = &dummyHandler;
+
 /* function below is also the middleware level, for enabling the user_logic,
  * which is above the middleware.
+ * TODO from saph: I am not entirely sure why we are having this function here.
+ * If user logic has to be enabled for all types of user logic interactions, we might as well
  * */
-volatile uint8_t *userlogic_reset_addr = (uint8_t *) (XMEM_OFFSET + 0x04);
-void userlogic_enable(void)
-{
+void userlogic_enable(void) {
     xmem_enableXmem();
-    *userlogic_reset_addr = 0;
-//    _delay_ms(1);
+    *userlogic_reset_addr = 0; // add _delay_ms(1); if something goes wrong
     xmem_disableXmem();
 }
 
-/* function below is get the id of the userlogic,
- * the id is set in userlogic
+/* *
+ * returns the userlogic id of the currently loaded bitfile
  * */
-volatile uint8_t *userlogic_id_addr = (uint8_t *) (XMEM_USERLOGIC_OFFSET +1500);
-void userlogic_read_id(void)
-{
+void userlogic_read_id(void) {
     uint8_t id;
 
     xmem_enableXmem();
@@ -50,38 +54,32 @@ void userlogic_read_id(void)
     debugWriteLine("\r\n");
     xmem_disableXmem();
 }
-//=================================================================================
 
-
-uint8_t isUartIdle(void)
-{
+uint8_t control_isUartIdle(void) {
     return currentUartReceiveMode != UART_IDLE;
 }
 
-void uartProcessInput(uint8_t currentData)
-{
+void dummyHandler(uint8_t currentData){
+    //dummy function as to never have the situation of having a function null pointer.
+    //tbf, if the control manager is enabled, performance isn't really an issue, anyway.
+}
 
-    switch(currentUartReceiveMode)
-    {
+void control_setUserHandle(void (*userHandler)(uint8_t)){
+    userDefinedHandler = userHandler;
+}
 
+void control_handleChar(uint8_t currentData) {
+    switch (currentUartReceiveMode) {
         case UART_IDLE:
         default:
-
-            // debugWriteString("Command: ");
-            // debugWriteChar(currentData);
-            // debugNewLine();
-            switch(currentData)
-            {
-                // fetching latency
-                // write to flash
+            switch (currentData) {
                 case 'F':
+                    //This the crucial case, enabled so that any debugging application can support writing new or
+                    // different bitfiles to the flash
+
                     // certain assumptions made about addresses aligning
                     // addresses must be aligned to 4K blocks 0xFFF000
-
                     // calculate what blocks need to be erased
-                    // TODO: use larger erase blocks
-                    // TODO: using non async communication
-
                     // acknowledge when ready to receive again
                     debugAck(currentData);
 
@@ -90,57 +88,56 @@ void uartProcessInput(uint8_t currentData)
                     unlockFlash(0); // To write data on FLASH, must unlock the flash
                     configurationUartFlash();
                     break;
-
-                case 'L':
-//                    reconfigure_fpgaMultiboot(0);
-
-                    xmem_enableXmem();
-                    *(addr_led) = (uint8_t) (0xff);
-                    *data = *(addr_led);
-//                    xmem_disableXmem();
-                    debugWriteLine("led_data: ");
-                    debugWriteHex8(*data);
-                    debugWriteLine("\r\n");
-                    break;
-                case 'l':
-
-                    xmem_enableXmem();
-                    *(addr_led) = (uint8_t) (0x00);
-                    *data = *(addr_led);
-//                    xmem_disableXmem();
-                    debugWriteLine("led_data: ");
-                    debugWriteHex8(*data);
-                    debugWriteLine("\r\n");
-                    break;
-                case 'r':
-                    reconfigure_fpgaMultiboot(0x0);
-                    break;
-                case 'R':
-                    reconfigure_fpgaMultiboot(0x90001);
-                    break;
-
-                case 'i':
-                    userlogic_enable();
-                    userlogic_read_id(); //
-
-                    break;
-
-
-                    // indicate readiness
                 default:
-                    // use this to check that mcu is receiving
-                    debugAck(currentData + 1);
-                    // debugWriteLine("echo");
-                    // uint8_t *ptr = malloc(1);
-                    // debugWriteHex16((uint16_t) ptr);
-                    // free(ptr);
-                    // debugWriteChar(' ');
-
+                    (*userDefinedHandler)(currentData);
                     break;
+//
+//                case 'L':
+//                    xmem_enableXmem();
+//                    *(addr_led) = (uint8_t) (0xff);
+//                    *data = *(addr_led);
+//                    debugWriteLine("led_data: ");
+//                    debugWriteHex8(*data);
+//                    debugWriteLine("\r\n");
+//                    break;
+//                case 'l':
+//                    xmem_enableXmem();
+//                    *(addr_led) = (uint8_t) (0x00);
+//                    *data = *(addr_led);
+//                    debugWriteLine("led_data: ");
+//                    debugWriteHex8(*data);
+//                    debugWriteLine("\r\n");
+//                    break;
+//                case 'r':
+//                    reconfigure_fpgaMultiboot(0x0);
+//                    break;
+//                case 'R':
+//                    reconfigure_fpgaMultiboot(0x90001);
+//                    break;
+//
+//                case 'i':
+//                    userlogic_enable();
+//                    userlogic_read_id(); //
+//
+//                    break;
+//
+//
+//                    // indicate readiness
+//                default:
+//                    // use this to check that mcu is receiving
+//                    debugAck(currentData + 1);
+//                    // debugWriteLine("echo");
+//                    // uint8_t *ptr = malloc(1);
+//                    // debugWriteHex16((uint16_t) ptr);
+//                    // free(ptr);
+//                    // debugWriteChar(' ');
+//
+//                    break;
             }
             break;
 
-        case UART_FLASH:break;
+        case UART_FLASH:
+            break;
     }
 }
 

--- a/lib/controlmanager/controlmanager.h
+++ b/lib/controlmanager/controlmanager.h
@@ -11,7 +11,10 @@ typedef enum {LOADING_IDLE, LOADING_JTAG, LOADING_SELECTMAP, LOAD_UART_FLASH, LO
 
 #define testingFlashAddress 0x180000
 
-uint8_t isUartIdle(void);
-void uartProcessInput(uint8_t uartData);
+uint8_t control_isUartIdle(void);
+void userlogic_enable(void);
+void userlogic_read_id(void);
+void control_setUserHandle(void (*userHandler)(uint8_t));
+void control_handleChar(uint8_t currentData);
 
 #endif //ELASTICNODEMIDDLEWARE_CONTROLMANAGER_H


### PR DESCRIPTION
To be able to have a debugging interface for users to flash new bitfiles we require some kind of (debugging) interface via uart that should be available at all times during the development of a new MW project. 
However the interface should be extensible to support more commands for development and debugging. 

By passing a function pointer in the main.c we can have the control manager call a custom handle function. 